### PR TITLE
fix: enable sticky comments in Claude Code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -52,7 +52,7 @@ jobs:
             Be constructive and helpful in your feedback.
 
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
-          # use_sticky_comment: true
+          use_sticky_comment: true
           
           # Optional: Customize review based on file types
           # direct_prompt: |


### PR DESCRIPTION
## Summary
Enable `use_sticky_comment: true` in the Claude Code review workflow to prevent review comments from flooding PRs with multiple revisions/commits.

## Changes
- Uncommented `use_sticky_comment: true` in `.github/workflows/claude-code-review.yml`
- This allows Claude Code to reuse the same comment thread for subsequent pushes to the same PR

## Rationale
This change reduces notification noise and keeps PR conversations cleaner by having Claude update its existing review comment rather than creating new ones for each push.

🤖 Generated with [Claude Code](https://claude.ai/code)